### PR TITLE
Add Salicru__SLC_1500_TWIN_PRO3__usbhid_ups__2.7.4__01.dev report…

### DIFF
--- a/Salicru/Salicru__SLC_1500_TWIN_PRO3__usbhid_ups__2.7.4__01.dev
+++ b/Salicru/Salicru__SLC_1500_TWIN_PRO3__usbhid_ups__2.7.4__01.dev
@@ -1,0 +1,81 @@
+# As initially reported in https://github.com/networkupstools/nut/issues/1142
+# modified back to "native" VID/PID (that report was done with UPS apparently
+# modified to reply to IDs supported by existing drivers to check its work
+# "out of the box":
+battery.capacity: 0.00
+battery.charge: 91
+battery.charge.low: 0
+battery.charge.restart: 0
+battery.charger.status: floating
+battery.protection: yes
+battery.runtime: 59940
+battery.runtime.low: 180
+battery.type: PbAc
+device.mfr: PHOENIXTEC
+device.model: SLC-1500-TWIN PRO3
+device.serial: CP10M3031700001
+device.type: ups
+driver.name: usbhid-ups
+driver.parameter.pollfreq: 30
+driver.parameter.pollinterval: 2
+driver.parameter.port: auto
+driver.parameter.synchronous: no
+driver.version: 2.7.4
+driver.version.data: MGE HID 1.40
+driver.version.internal: 0.41
+input.frequency.nominal: 50
+input.voltage.nominal: 230
+outlet.1.status: on
+output.current: 0.00
+output.frequency: 50.0
+output.frequency.nominal: 50
+output.voltage: 230.2
+output.voltage.nominal: 230
+ups.date: 2019/12/31
+ups.delay.shutdown: 20
+ups.delay.start: 30
+ups.firmware: 00.01.9319
+ups.load: 0
+ups.mfr: PHOENIXTEC
+ups.model: SLC-1500-TWIN PRO3
+ups.power: 0
+ups.power.nominal: 1500
+ups.productid: 0201
+ups.realpower: 0
+ups.realpower.nominal: 1500
+ups.serial: CP10M3031700001
+ups.shutdown: enabled
+ups.status: OL CHRG
+ups.temperature: 25.9
+ups.test.interval: 2592000
+ups.test.result: Done and passed
+ups.time: 20:18:14
+ups.timer.shutdown: 0
+ups.timer.start: 0
+ups.type: online
+ups.vendorid: 2e66
+
+# $ upsrw -s battery.runtime.low Unity
+# Enter new value for battery.runtime.low: 240
+# OK
+#
+# $ upsc Unity battery.runtime.low
+# 240
+# I successfully set the “ups.delay.shutdown” from 20 to 120 via “upsrw -s ups.delay.shutdown Unity” command
+
+# $ upscmd -l Unity
+# Instant commands supported on UPS [Unity]:
+#
+# load.off - Turn off the load immediately
+# load.off.delay - Turn off the load with a delay (seconds)
+# load.on - Turn on the load immediately
+# load.on.delay - Turn on the load with a delay (seconds)
+# shutdown.return - Turn off the load and return when power is back
+# shutdown.stayoff - Turn off the load and remain off
+# shutdown.stop - Stop a shutdown in progress
+# test.battery.start.deep - Start a deep battery test
+# test.battery.start.quick - Start a quick battery test
+# test.battery.stop - Stop the battery test
+#
+# Send command “upscmd Unity load.off” , the output voltage has changed from 230.2 to 0 after loading off.
+# Send command “upscmd Unity load.on”, the output voltage has changed from 0 to 230.2 after loading on.

--- a/Salicru/Salicru__SPS_Home_850__usbhid_ups__2.7.4.1__01.dev
+++ b/Salicru/Salicru__SPS_Home_850__usbhid_ups__2.7.4.1__01.dev
@@ -1,0 +1,47 @@
+# First report for new salicru HID subdriver from
+# https://github.com/networkupstools/nut/issues/732
+# https://github.com/networkupstools/nut/pull/1199
+# for Salicru SPS 850 HOME: https://www.salicru.com/sps-home.html
+# Note the weird "manufacturer" name of "1 ", which
+# seems to be true (same reported by other tools).
+
+# $ ./clients/upsc salicru@localhost
+battery.charge.low: 10
+battery.charge.warning: 20
+battery.mfr.date: 1 
+battery.runtime: 1440
+battery.runtime.low: 300
+battery.type: PbAcid
+battery.voltage.nominal: 12
+device.mfr: 1 
+device.model:  850
+device.serial:                 
+device.type: ups
+driver.name: usbhid-ups
+driver.parameter.pollfreq: 30
+driver.parameter.pollinterval: 2
+driver.parameter.port: auto
+driver.parameter.synchronous: no
+driver.version: 2.7.4-3304-g6135bb65
+driver.version.data: Salicru HID 0.1
+driver.version.internal: 0.43
+input.frequency: 50.2
+input.transfer.high: 270
+input.transfer.low: 180
+input.voltage: 224.5
+input.voltage.nominal: 230
+output.frequency: 50.2
+output.voltage: 224.5
+ups.beeper.status: enabled
+ups.delay.shutdown: 20
+ups.delay.start: 30
+ups.load: 18
+ups.mfr: 1 
+ups.model:  850
+ups.productid: 0300
+ups.realpower.nominal: 490
+ups.serial:                 
+ups.status: OL
+ups.timer.shutdown: -60
+ups.timer.start: -60
+ups.vendorid: 2e66

--- a/Salicru/Salicru__SPS_Home_850__usbhid_ups__2.7.4.1__02.dev
+++ b/Salicru/Salicru__SPS_Home_850__usbhid_ups__2.7.4.1__02.dev
@@ -1,0 +1,42 @@
+# Second report for new salicru HID subdriver from
+# https://github.com/networkupstools/nut/issues/732
+# https://github.com/networkupstools/nut/pull/1199
+# for Salicru SPS 850 HOME: https://www.salicru.com/sps-home.html
+# Note the weird "manufacturer" name of "1 ", which
+# seems to be true (same reported by other tools).
+
+# $ ./clients/upsc salicru@localhost 
+battery.charge: 100
+battery.charge.low: 10
+battery.charge.warning: 20
+battery.runtime: 1440
+battery.runtime.low: 300
+battery.type: PbAcid
+battery.voltage: 13.50
+battery.voltage.nominal: 12
+device.mfr: 1 
+device.model:  850
+device.serial:                 
+device.type: ups
+driver.name: usbhid-ups
+driver.parameter.pollfreq: 30
+driver.parameter.pollinterval: 2
+driver.parameter.port: auto
+driver.parameter.synchronous: no
+driver.version: 2.7.4-3324-g845d808c
+driver.version.data: Salicru HID 0.1
+driver.version.internal: 0.43
+input.frequency: 50.0
+input.voltage: 224.5
+input.voltage.nominal: 230
+output.frequency: 50.0
+output.voltage: 224.5
+ups.beeper.status: enabled
+ups.load: 18
+ups.mfr: 1 
+ups.model:  850
+ups.productid: 0300
+ups.realpower.nominal: 490
+ups.serial:                 
+ups.status: OL
+ups.vendorid: 2e66


### PR DESCRIPTION
…from issue networkupstools/nut#1142

<!-- Comment:
## Proposing a new NUT Devices Dumps Library (DDL) entry

First of all, thank you for taking the time for preparing this contribution!

Please follow the file naming and content mark-up rules explained at current
https://networkupstools.org/ddl/index.html#_file_naming_convention
section and the text below it.

To report new data for the Devices Dumps Library (DDL), such "data dump"
reports can be best prepared by the
https://raw.githubusercontent.com/networkupstools/nut/master/tools/nut-ddl-dump.sh
script from the main NUT codebase; at a minimum, output of `upsc` helps too.
-->

## Sanity check list

- [x] This PR is named to help easy searches (identify the vendor, device...)

- [x] Data dump file name follows this pattern (safely using ASCII characters):
  `<manufacturer>__<model>__<driver-name>__<nut-version>__<report-number>.<extension>`
  (more nuances are documented on site).

- [x] This file is placed into a sub-directory named same as the `manufacturer`.

- [x] Information from `upsc` discovered fields is provided un-commented.

- [ ] Additional data about supported RW variables and instant commands is
  prefixed with standardized comment mark-up as documented on site, e.g.:
````
#RW:<var.name>:<type>:<options>
````
and
````
#CMD:<command.name>
````

- [ ] Mark-up for structured comments is followed, where applicable.

- [ ] For devices supported only with special settings in their `ups.conf`
  configuration section (e.g. `vendorid` and `productid` required along
  with a USB `subdriver`), example section content is welcome as a comment.

- [x] For a newly discovered supported device, a sibling PR for the main
  NUT codebase (at least `docs/driver.list.in`, or possibly VID/PID and
  other auto-detection mapping tables in the driver sources) is welcome.

- [x] This PR is linked to relevant issue(s) and/or PRs in the NUT project
  if applicable
