### PR TITLE
Add dev file for Salicru SPS 850 ADV T

### DIFF
--- a/Salicru/Salicru__SPS_850_ADV_T__usbhid_ups__2.8.0__01.dev
+++ b/Salicru/Salicru__SPS_850_ADV_T__usbhid_ups__2.8.0__01.dev
@@ -1,0 +1,66 @@
+# First report for new salicru HID subdriver from
+# https://github.com/networkupstools/nut/issues/1416
+# for Salicru SPS 850 ADV T: https://www.salicru.com/sps-850-adv-t.html
+
+# $ upsc salicru
+battery.charge: 100
+battery.charge.low: 10
+battery.charge.warning: 20
+battery.runtime: 4500
+battery.runtime.low: 300
+battery.type: PbAcid
+battery.voltage: 26.00
+battery.voltage.nominal: 24
+device.mfr: 1
+device.model:  850
+device.serial: 000000000000
+device.type: ups
+driver.name: usbhid-ups
+driver.parameter.pollfreq: 30
+driver.parameter.pollinterval: 2
+driver.parameter.port: auto
+driver.parameter.productid: 0302
+driver.parameter.synchronous: auto
+driver.parameter.vendorid: 2e66
+driver.version: 2.8.0-21-gf8462e88a
+driver.version.data: Salicru HID 0.3
+driver.version.internal: 0.47
+driver.version.usb: libusb-0.1 (or compat)
+input.frequency: 50.2
+input.voltage: 228.0
+input.voltage.nominal: 230
+output.frequency: 50.2
+output.voltage: 22.8
+output.voltage.nominal: 24
+ups.beeper.status: enabled
+ups.load: 11
+ups.mfr: 1
+ups.model:  850
+ups.productid: 0302
+ups.realpower.nominal: 595
+ups.serial: 000000000000
+ups.status: OL
+ups.vendorid: 2e66
+
+# :; upsrw salicru
+# [battery.charge.low]
+# Remaining battery level when UPS switches to LB (percent)
+# Type: STRING
+# Maximum length: 10
+# Value: 10
+# 
+# [battery.runtime.low]
+# Remaining battery runtime when UPS switches to LB (seconds)
+# Type: STRING
+# Maximum length: 10
+# Value: 300
+
+# :; upscmd -l salicru
+# Instant commands supported on UPS [salicru]:
+# 
+
+# NOTE: I tried to set the value of `battery.runtime.low` and 
+# `battery.charge.low` using `upsrw`, but although the command returns OK,
+# no values seem to be modified.
+
+


### PR DESCRIPTION
This PR contail the `upsc` (as well as `upsrw` and `upscmd -l`) outputs for Salicru SPS 850 ADV T. This device was added as supported in the PR https://github.com/networkupstools/nut/pull/1418 as discussed in https://github.com/networkupstools/nut/issues/1416.

<!-- Comment:
## Proposing a new NUT Devices Dumps Library (DDL) entry

First of all, thank you for taking the time for preparing this contribution!

Please follow the file naming and content mark-up rules explained at current
https://networkupstools.org/ddl/index.html#_file_naming_convention
section and the text below it.

To report new data for the Devices Dumps Library (DDL), such "data dump"
reports can be best prepared by the
https://raw.githubusercontent.com/networkupstools/nut/master/tools/nut-ddl-dump.sh
script from the main NUT codebase; at a minimum, output of `upsc` helps too.
-->

## Sanity check list

- [X] This PR is named to help easy searches (identify the vendor, device...)

- [X] Data dump file name follows this pattern (safely using ASCII characters):
  `<manufacturer>__<model>__<driver-name>__<nut-version>__<report-number>.<extension>`
  (more nuances are documented on site).

- [X] This file is placed into a sub-directory named same as the `manufacturer`.

- [ ] Was this content prepared with `nut-ddl-dump.sh` script?

- [X] Information from `upsc` discovered fields is provided un-commented.

- [X] Additional data about supported RW variables and/or instant commands
  is provided (as comments)...

- [ ] ...prefixed with standardized comment mark-up as documented on site,
  e.g.:
````
#RW:<var.name>:<type>:<options>
````
and
````
#CMD:<command.name>
````
<!-- Comment:
For manually written/pasted submissions, information from these tools can be
provided as plain comments. While this would not allow for automated parsing
and similar consumption of info, it is better than nothing for human readers.
-->

- [ ] Mark-up for other structured comments is followed (for fields, vars,
  etc. as documented on site), where applicable.

- [ ] For devices supported only with special settings in their `ups.conf`
  configuration section (e.g. `vendorid` and `productid` required along
  with a USB `subdriver`), example section content is welcome as a comment.

- [ ] For a newly discovered supported device, a sibling PR for the main
  NUT codebase (at least `docs/driver.list.in`, or possibly VID/PID and
  other auto-detection mapping tables in the driver sources) is welcome.

- [X] This PR is linked to relevant issue(s) and/or PRs in the NUT project
  if applicable.
