### PR TITLE
Fix currently remaining markup which is not structured comments

### DIFF
--- a/APC/APC__Smart-UPS_SC450_RM__apcsmart__2.6.1__01.dev
+++ b/APC/APC__Smart-UPS_SC450_RM__apcsmart__2.6.1__01.dev
@@ -77,7 +77,7 @@ ups.test.result: NO
 #RW:input.transfer.low:ENUM:"204"
 #RW:input.transfer.low:ENUM:"200"
 #RW:input.transfer.low:ENUM:"196"
-#RW:output.voltage.nominal:ENUM"230"
+#RW:output.voltage.nominal:ENUM:"230"
 #RW:ups.delay.shutdown:ENUM:"060"
 #RW:ups.delay.shutdown:ENUM:"180"
 #RW:ups.delay.shutdown:ENUM:"300"

--- a/APC/APC__Smart-UPS_SC450_RM__apcsmart__2.6.1__01.dev
+++ b/APC/APC__Smart-UPS_SC450_RM__apcsmart__2.6.1__01.dev
@@ -40,6 +40,7 @@ ups.serial: 5S1107T50479
 ups.status: OL
 ups.test.interval: 1209600
 ups.test.result: NO
+
 #CMD:calibrate.start
 #CMD:calibrate.stop
 #CMD:load.off
@@ -51,6 +52,7 @@ ups.test.result: NO
 #CMD:test.battery.stop
 #CMD:test.failure.start
 #CMD:test.panel.start
+
 #RW:battery.alarm.threshold:ENUM:"0"
 #RW:battery.alarm.threshold:ENUM:"T"
 #RW:battery.alarm.threshold:ENUM:"L"

--- a/Eaton/Eaton__5E1100iUSB__usbhid-ups__2.7.1__01.dev
+++ b/Eaton/Eaton__5E1100iUSB__usbhid-ups__2.7.1__01.dev
@@ -1,4 +1,4 @@
-# DEVICE:URL:REPORT: https://lists.alioth.debian.org/pipermail/nut-upsdev/2015-July/007069.html or
+# DEVICE:URL:REPORT: https://lists.alioth.debian.org/pipermail/nut-upsdev/2015-July/007069.html
 # DEVICE:URL:REPORT: http://news.gmane.org/find-root.php?message_id=CAE396RSOQeUcTH50%2befMSpj7Dn3iHDZX6%3dDGayTpAjKZfXut7A%40mail.gmail.com
 # DEVICE:URL:VENDOR: http://powerquality.eaton.com/5E1100iUSB.aspx?CX&GUID=8D85FE66-3102-427C-8F33-B8D56BBDD4D3
 

--- a/Greencell/Greencell__Micropower_600__blazer_usb__2.7.4__01.dev
+++ b/Greencell/Greencell__Micropower_600__blazer_usb__2.7.4__01.dev
@@ -1,4 +1,4 @@
-# DEVICE:URL:REPORT: https://github.com/networkupstools/nut/issues/1080 :
+# DEVICE:URL:REPORT: https://github.com/networkupstools/nut/issues/1080
 
 # DEVICE:COMMENT:
 # The UPS looks to be using working with the `blazer_usb` driver,

--- a/Ippon/Ippon__Back_Comfo_Pro_II_650-850-1050__blazer_usb__2.7.4__01.dev
+++ b/Ippon/Ippon__Back_Comfo_Pro_II_650-850-1050__blazer_usb__2.7.4__01.dev
@@ -11,7 +11,7 @@
 # * the return value is null by command `upsrw ippon`.
 # DEVICE:EOC
 
-### upsc test result:
+# upsc test result:
 battery.charge: 100
 battery.voltage: 13.60
 battery.voltage.high: 13.00

--- a/Micropower/Micropower__LCD_1000__blazer_usb__2.7.1__01.dev
+++ b/Micropower/Micropower__LCD_1000__blazer_usb__2.7.1__01.dev
@@ -1,4 +1,4 @@
-# DEVICE:URL:REPORT: https://lists.alioth.debian.org/pipermail/nut-upsdev/2015-September/007085.html or
+# DEVICE:URL:REPORT: https://lists.alioth.debian.org/pipermail/nut-upsdev/2015-September/007085.html
 # DEVICE:URL:REPORT: http://news.gmane.org/find-root.php?message_id=CAJpc0%5fJHWwE%2ba4Uq%5fpDO3bdPQu%2dsD%2d%2dDRvWTfz%3dz57g8k%3dqqNQ%40mail.gmail.com
 
 # DEVICE:COMMENT:

--- a/Powerware/Powerware__PW5125__bcmxcp__2.7.4__01.dev
+++ b/Powerware/Powerware__PW5125__bcmxcp__2.7.4__01.dev
@@ -66,9 +66,9 @@ ups.test.result: No test initiated
 #RW:battery.packs:STRING:1
 #RW:outlet.1.delay.shutdown:STRING:5
 #RW:outlet.1.delay.start:STRING:5
-#RW:outlet.2.delay.shutdown :STRING: 5
-#RW:outlet.2.delay.start:STRING: 5
-#RW:output.voltage.nominal:STRING: 3
+#RW:outlet.2.delay.shutdown:STRING:5
+#RW:outlet.2.delay.start:STRING:5
+#RW:output.voltage.nominal:STRING:3
 
 #CMD:beeper.disable
 #CMD:beeper.enable

--- a/Tripp_Lite/Tripp_Lite__SMART1000LCD__usbhid-ups__2.6.3__02.dev
+++ b/Tripp_Lite/Tripp_Lite__SMART1000LCD__usbhid-ups__2.6.3__02.dev
@@ -1,4 +1,4 @@
-# DEVICE:URL:REPORT: https://lists.alioth.debian.org/pipermail/nut-upsuser/2013-October/008675.html 
+# DEVICE:URL:REPORT: https://lists.alioth.debian.org/pipermail/nut-upsuser/2013-October/008675.html
 battery.charge: 100
 battery.runtime: 5760
 battery.type: PbAc

--- a/nJoy/nJoy__Keen-600__blazer_ser__2.7.4__01.dev
+++ b/nJoy/nJoy__Keen-600__blazer_ser__2.7.4__01.dev
@@ -1,6 +1,6 @@
 # DEVICE:URL:REPORT: https://github.com/networkupstools/nut/issues/867
 # DEVICE:URL:VENDOR: https://www.njoy.global/product/keen-600
-### DEVICE:URL:VENDOR: link:https://www.njoy.ro/UPS/keen-600
+# DEVICE:URL:VENDOR: link:https://www.njoy.ro/UPS/keen-600[Possibly an obsolete product page link]
 
 # DEVICE:COMMENT:
 # From https://github.com/networkupstools/nut/issues/867 :


### PR DESCRIPTION
Makes use of feature https://github.com/networkupstools/nut-website/pull/43 to complete issue #29 after work on #33

Note that *some* un-structured markup remains, e.g. `upsc output` lines, comments in the `ddl/Manufacturer_Name/Manufacturer_Name__Actual_Model__driver-name__2.7.1__01.nds` template/example file, and a couple others. Normally there should not appear more of those.

TOTHINK: A coverage-style CI check with count of such lines?..