### PR TITLE
Create Greencell__PowerProof_2000__nutdrv_qx__2.8.0__01.dev

### DIFF
--- a/Greencell/Greencell__PowerProof_2000__nutdrv_qx__2.8.0__01.dev
+++ b/Greencell/Greencell__PowerProof_2000__nutdrv_qx__2.8.0__01.dev
@@ -1,0 +1,97 @@
+# DEVICE:URL:REPORT: https://github.com/networkupstools/nut/issues/2727
+
+# DEVICE:COMMENT:
+# The UPS looks to be working with the `nutdrv_qx` driver,
+# different status events are properly reported.
+#
+# The (v2.8.0) `nut-scanner` tool suggested `nutdrv_qx` driver
+# according to vendorid/productid which is used in many unrelated
+# devices, that driver supports the (Qx) protocol here.
+# DEVICE:EOC
+
+# DEVICE:COMMENT-BLOCK:UPSCONF:
+# maxretry = 1
+# pollinterval = 2
+# battery_voltage_reports_one_pack
+# 
+# [gc2000va]
+#   driver = nutdrv_qx
+#   protocol = q1 
+#   port = auto
+#   desc = "Green Cell PowerProof 2000VA UPS05"
+#   chargetime = 28800
+#   idleload = 4
+#   default.battery.type = PbAcid
+#   default.battery.capacity.nominal = 18.0
+#   default.battery.charge.low = 10
+#   default.battery.charge.warning = 50
+#   default.battery.voltage.nominal = 24
+#   default.battery.voltage.low = 21.00
+#   default.battery.voltage.high = 25.00
+#   default.battery.packs = 2
+#   runtimecal = 2340,8,4740,4
+#   default.input.frequency.nominal= 50.0
+#   default.input.voltage.nominal= 230.0
+#   default.output.current.nominal = 8.0
+#   default.output.frequency.nominal = 50.0
+#   default.output.voltage.nominal = 230.0
+#   default.ups.mfr = "Green Cell"
+#   default.ups.model = "PowerProof 2000VA UPS05"
+#   default.ups.mfr.date = "2024/12/17"
+#   default.ups.vendor = "Fry's Electronics"
+#   default.ups.product = "MEC0003"
+#   default.ups.power.nominal = "2000"
+#   default.ups.realpower.nominal = "1200"
+# DEVICE:EOC
+
+battery.capacity.nominal: 18.0
+battery.charge: 100
+battery.charge.low: 10
+battery.charge.warning: 50
+battery.packs: 2
+battery.runtime: 4468
+battery.type: PbAcid
+battery.voltage: 27.40
+battery.voltage.high: 25.00
+battery.voltage.low: 21.00
+battery.voltage.nominal: 24
+device.mfr: Green Cell
+device.model: PowerProof 2000VA UPS05
+device.type: ups
+driver.name: nutdrv_qx
+driver.parameter.chargetime: 28800
+driver.parameter.idleload: 4
+driver.parameter.pollfreq: 30
+driver.parameter.pollinterval: 2
+driver.parameter.port: auto
+driver.parameter.protocol: q1
+driver.parameter.runtimecal: 2340,8,4740,4
+driver.parameter.synchronous: auto
+driver.version: 2.8.0
+driver.version.data: Q1 0.07
+driver.version.internal: 0.32
+driver.version.usb: libusb-1.0.26 (API: 0x1000109)
+input.frequency: 50.1
+input.frequency.nominal: 50.0
+input.voltage: 238.7
+input.voltage.fault: 238.7
+input.voltage.nominal: 230.0
+output.current.nominal: 8.0
+output.frequency.nominal: 50.0
+output.voltage: 239.2
+output.voltage.nominal: 230.0
+ups.beeper.status: enabled
+ups.delay.shutdown: 30
+ups.delay.start: 180
+ups.load: 3
+ups.mfr: Green Cell
+ups.mfr.date: 2024/12/17
+ups.model: PowerProof 2000VA UPS05
+ups.power.nominal: 2000
+ups.product: MEC0003
+ups.productid: 0000
+ups.realpower.nominal: 1200
+ups.status: OL
+ups.type: offline / line interactive
+ups.vendor: Fry's Electronics
+ups.vendorid: 0001


### PR DESCRIPTION
<!-- Comment:
## Proposing a new NUT Devices Dumps Library (DDL) entry

First of all, thank you for taking the time for preparing this contribution!

Please follow the file naming and content mark-up rules explained at current
https://networkupstools.org/ddl/index.html#_file_naming_convention
section and the text below it.

To report new data for the Devices Dumps Library (DDL), such "data dump"
reports can be best prepared by the
https://raw.githubusercontent.com/networkupstools/nut/master/tools/nut-ddl-dump.sh
script from the main NUT codebase; at a minimum, output of `upsc` helps too.
-->

## Sanity check list

- [x] This PR is named to help easy searches (identify the vendor, device...)

- [x] Data dump file name follows this pattern (safely using ASCII characters):
  `<manufacturer>__<model>__<driver-name>__<nut-version>__<report-number>.<extension>`
  (more nuances are documented on site).

- [x] This file is placed into a sub-directory named same as the `manufacturer`.

- [ ] Was this content prepared with `nut-ddl-dump.sh` script?

- [x] Information from `upsc` discovered fields is provided un-commented.

- [x] Additional data about supported RW variables and/or instant commands
  is provided (as comments)...

- [x] ...prefixed with standardized comment mark-up as documented on site,
  e.g.:
````
#RW:<var.name>:<type>:<options>
````
and
````
#CMD:<command.name>
````
<!-- Comment:
For manually written/pasted submissions, information from these tools can be
provided as plain comments. While this would not allow for automated parsing
and similar consumption of info, it is better than nothing for human readers.
-->

- [x] Mark-up for other structured comments is followed (for fields, vars,
  etc. as documented on site), where applicable.

- [ ] For devices supported only with special settings in their `ups.conf`
  configuration section (e.g. `vendorid` and `productid` required along
  with a USB `subdriver`), example section content is welcome as a comment.

- [x] For a newly discovered supported device, a sibling PR for the main
  NUT codebase (at least
  [`docs/driver.list.in`](https://github.com/networkupstools/nut/blob/master/data/driver.list.in),
  or possibly VID/PID and other auto-detection mapping tables in the driver
  sources) is welcome.

- [x] This PR is linked to relevant issue(s) and/or PRs in the NUT project,
  if applicable (new driver submissions, bug fixes/discussions, etc.).
