### PR TITLE
PiJuice/*: Add some PiJuice HAT reports (old and new)

### DIFF
--- a/PiSupply/PiSupply__PiJuice_HAT__pijuice__2.8.0__01.dev
+++ b/PiSupply/PiSupply__PiJuice_HAT__pijuice__2.8.0__01.dev
@@ -1,0 +1,37 @@
+# DEVICE:URL:REPORT: https://github.com/networkupstools/nut/pull/730
+# DEVICE:URL:VENDOR: https://uk.pi-supply.com/products/pijuice-standard
+
+# DEVICE:COMMENT-BLOCK:UPSCONF:
+# [hat]
+#     driver = pijuice
+#     port = /dev/i2c-1
+#     desc = "PiJuice HAT"
+# DEVICE:EOC
+
+battery.capacity: 1.820
+battery.charge: 93.7
+battery.charge.low: 25
+battery.charger.status: resting
+battery.current: 0.010
+battery.packs: 1
+battery.packs.bad: 0
+battery.temperature: 48
+battery.type: LiPO
+battery.voltage: 4.113
+battery.voltage.nominal: 4.180
+device.mfr: PiJuice
+device.type: HAT
+driver.name: pijuice
+driver.parameter.pollinterval: 2
+driver.parameter.port: /dev/i2c-1
+driver.parameter.synchronous: no
+driver.version: 2.7.4-731-gc0a0e56
+driver.version.internal: 0.9
+input.current: 1.727
+input.voltage: 5.014
+ups.date: 2019-09-12
+ups.firmware: 1.3
+ups.mfr: PiJuice
+ups.status: HB OL
+ups.time: 23:53:56.92
+ups.type: HAT

--- a/PiSupply/PiSupply__PiJuice_HAT__pijuice__2.8.0__02.dev
+++ b/PiSupply/PiSupply__PiJuice_HAT__pijuice__2.8.0__02.dev
@@ -1,0 +1,37 @@
+# DEVICE:URL:REPORT: https://github.com/PiSupply/PiJuice/issues/124#issuecomment-1018603688
+# DEVICE:URL:VENDOR: https://uk.pi-supply.com/products/pijuice-standard
+
+# DEVICE:COMMENT-BLOCK:UPSCONF:
+# [hat]
+#     driver = pijuice
+#     port = /dev/i2c-1
+#     desc = "PiJuice HAT"
+# DEVICE:EOC
+
+battery.capacity: 1.000	#BAD: Actual battery was 1820 mAh; possibly wrong DIP switch combo was in place to configure the HAT
+battery.charge: 5.0
+battery.charge.low: 25
+battery.charger.status: charging
+battery.current: -0.168
+battery.packs: 1
+battery.packs.bad: 0
+battery.temperature: 56
+battery.type: LiPO
+battery.voltage: 3.648
+battery.voltage.nominal: 4.180
+device.mfr: PiJuice
+device.type: HAT
+driver.name: pijuice
+driver.parameter.pollinterval: 2
+driver.parameter.port: /dev/i2c-1
+driver.parameter.synchronous: no
+driver.version: 2.7.4-4385-g2bd17f540
+driver.version.internal: 0.9
+input.current: -0.592
+input.voltage: 4.966
+ups.date: 2022-01-21
+ups.firmware: 1.4
+ups.mfr: PiJuice
+ups.status: LB OL CHRG
+ups.time: 15:15:44.88
+ups.type: HAT

--- a/PiSupply/PiSupply__PiJuice_HAT__pijuice__2.8.0__03.dev
+++ b/PiSupply/PiSupply__PiJuice_HAT__pijuice__2.8.0__03.dev
@@ -1,0 +1,160 @@
+# DEVICE:URL:REPORT: https://github.com/PiSupply/PiJuice/issues/124#issuecomment-1018603688
+# DEVICE:URL:VENDOR: https://uk.pi-supply.com/products/pijuice-standard
+
+# DEVICE:COMMENT-BLOCK:UPSCONF:
+# [hat]
+#     driver = pijuice
+#     port = /dev/i2c-1
+#     desc = "PiJuice HAT"
+# DEVICE:EOC
+
+# DEVICE:COMMENT-BLOCK: DRIVER START LOG
+#    0.000000     [D5] send_to_all: SETINFO driver.parameter.port "/dev/i2c-1"
+#    0.000247     [D1] debug level is '6'
+#    0.001303     [D5] send_to_all: SETINFO device.type "ups"
+#    0.001446     [D3] get_firmware_version
+#    0.002954     Unknown Firmware release: 1.4
+#    0.003016     [D1] UPS Firmware Version: 1.4
+#    0.003074     [D5] send_to_all: SETINFO ups.firmware "1.4"
+#    0.003136     [D5] send_to_all: SETINFO driver.version "2.7.4-4385-g2bd17f540"
+#    0.003195     [D5] send_to_all: SETINFO driver.version.internal "0.9"
+#    0.003252     [D5] send_to_all: SETINFO driver.name "pijuice"
+#    0.003309     [D5] send_to_all: SETINFO ups.mfr "PiJuice"
+#    0.003365     [D5] send_to_all: SETINFO ups.type "HAT"
+#    0.003422     [D5] send_to_all: SETINFO device.mfr "PiJuice"
+#    0.003477     [D5] send_to_all: SETINFO device.type "HAT"
+#    0.003533     [D1] Low Battery Threshold: 25%
+#    0.003589     [D5] send_to_all: SETINFO battery.charge.low "25"
+#    0.003642     [D1] Nominal Battery Voltage: 4.180V
+#    0.003697     [D5] send_to_all: SETINFO battery.voltage.nominal "4.180"
+#    0.003747     [D3] get_i2c_address
+#    0.004934     [D1] I2C Address: 0x14
+#    0.005001     [D1] Found device '0x14' on port '/dev/i2c-1'
+#    0.005049     [D3] get_battery_profile
+#    0.009196     [D1] Battery Capacity: 1.820Ah
+#    0.009271     [D5] send_to_all: SETINFO battery.capacity "1.820"
+#    0.009321     [D3] get_battery_profile_ext
+#    0.014312     [D1] Battery Chemistry: LiPO
+#    0.014389     [D5] send_to_all: SETINFO battery.type "LiPO"
+#    0.014444     [D3] get_status
+#    0.015638     [D1] Battery Status: Normal
+#    0.015703     [D5] send_to_all: SETINFO battery.packs "1"
+#    0.015763     [D5] send_to_all: SETINFO battery.packs.bad "0"
+#    0.015814     [D1] Power Input: Not Present
+#    0.015862     [D1] Power Input 5v: Present
+#    0.015910     [D3] get_charge_level_hi_res
+#    0.017323     [D1] Battery Charge Level: 51.0%
+#    0.017389     [D5] send_to_all: SETINFO battery.charge "51.0"
+#    0.017437     On USB power
+#    0.017548     [D1] On USB power [1:0:0]
+#    0.017599     [D1] Battery Charger Status: resting
+#    0.017653     [D5] send_to_all: SETINFO battery.charger.status "resting"
+#    0.017698     [D3] get_battery_temperature
+#    0.018972     [D1] Battery Temperature: 123°C
+#    0.019030     [D5] send_to_all: SETINFO battery.temperature "123"
+#    0.019074     [D3] get_battery_voltage
+#    0.020351     [D1] Battery Voltage: 3.700V
+#    0.020406     [D5] send_to_all: SETINFO battery.voltage "3.700"
+#    0.020448     [D3] get_battery_current
+#    0.021728     [D1] Battery Current: 0.264A
+#    0.021791     [D5] send_to_all: SETINFO battery.current "0.264"
+#    0.021834     [D3] get_io_voltage
+#    0.023122     [D1] Input Voltage: 4.994V
+#    0.023176     [D5] send_to_all: SETINFO input.voltage "4.994"
+#    0.023219     [D3] get_io_current
+#    0.024520     [D1] Input Current: 0.064A
+#    0.024578     [D5] send_to_all: SETINFO input.current "0.064"
+#    0.024621     [D3] get_time
+#    0.027337     [D1] UPS Time: 21:48:40.41
+#    0.027400     [D5] send_to_all: SETINFO ups.time "21:48:40.41"
+#    0.027445     [D1] UPS Date: 2022-01-21
+#    0.027493     [D5] send_to_all: SETINFO ups.date "2022-01-21"
+#    0.027536     [D3] get_power_off
+#    0.028605     [D1] Power Off: DISABLED
+#    0.028660     [D5] send_to_all: SETINFO ups.status "OL"
+#    0.028705     [D5] send_to_all: DATAOK
+#    0.028754     [D5] send_to_all: SETINFO driver.parameter.pollinterval "2"
+#    0.028803     [D5] send_to_all: SETINFO driver.parameter.synchronous "no"
+#    0.028851     [D3] get_status
+#    0.029951     [D1] Battery Status: Normal
+#    0.030010     [D1] Power Input: Not Present
+#    0.030052     [D1] Power Input 5v: Present
+#    0.030092     [D3] get_charge_level_hi_res
+#    0.031379     [D1] Battery Charge Level: 51.0%
+#    0.031431     [D1] On USB power [1:0:0]
+#    0.031472     [D1] Battery Charger Status: resting
+#    0.031516     [D3] get_battery_temperature
+#    0.032790     [D1] Battery Temperature: 251°C
+#    0.032845     [D5] send_to_all: SETINFO battery.temperature "251"
+#    0.032888     [D3] get_battery_voltage
+#    0.034167     [D1] Battery Voltage: 3.828V
+#    0.034228     [D5] send_to_all: SETINFO battery.voltage "3.828"
+#    0.034270     [D3] get_battery_current
+#    0.035546     [D1] Battery Current: 0.264A
+#    0.035596     [D3] get_io_voltage
+#    0.036884     [D1] Input Voltage: 4.991V
+#    0.036937     [D5] send_to_all: SETINFO input.voltage "4.991"
+#    0.036979     [D3] get_io_current
+#    0.038280     [D1] Input Current: 0.064A
+#    0.038387     [D3] get_time
+#    0.041102     [D1] UPS Time: 21:48:40.39
+#    0.041158     [D5] send_to_all: SETINFO ups.time "21:48:40.39"
+#    0.041202     [D1] UPS Date: 2022-01-21
+#    0.041247     [D3] get_power_off
+#    0.042321     [D1] Power Off: DISABLED
+#    0.042380     [D3] get_status
+#    0.043475     [D1] Battery Status: Normal
+#    0.043527     [D1] Power Input: Not Present
+#    0.043568     [D1] Power Input 5v: Present
+#    0.043610     [D3] get_charge_level_hi_res
+#    0.044899     [D1] Battery Charge Level: 51.0%
+#    0.044952     [D1] On USB power [1:0:0]
+#    0.044994     [D1] Battery Charger Status: resting
+#    0.045038     [D3] get_battery_temperature
+#    0.046314     [D1] Battery Temperature: 251°C
+#    0.046372     [D3] get_battery_voltage
+#    0.047647     [D1] Battery Voltage: 3.700V
+#    0.047701     [D5] send_to_all: SETINFO battery.voltage "3.700"
+#    0.047743     [D3] get_battery_current
+#    0.049021     [D1] Battery Current: 0.264A
+#    0.049071     [D3] get_io_voltage
+#    0.050360     [D1] Input Voltage: 4.988V
+#    0.050420     [D5] send_to_all: SETINFO input.voltage "4.988"
+#    0.050462     [D3] get_io_current
+#    0.051760     [D1] Input Current: 0.064A
+#    0.051812     [D3] get_time
+#    0.054527     [D1] UPS Time: 21:48:40.38
+#    0.054588     [D5] send_to_all: SETINFO ups.time "21:48:40.38"
+#    0.054633     [D1] UPS Date: 2022-01-21
+#    0.054678     [D3] get_power_off
+#    0.055747     [D1] Power Off: DISABLED
+#    0.055797     [D3] Entering dstate_dump
+# DEVICE:EOC
+
+battery.capacity: 1.820	#BAD: Actual battery was 12000 mAh; possibly wrong DIP switch combo was in place to configure the HAT
+battery.charge: 51.0	#BAD: (?) Not 100% but charger is "resting"...
+battery.charge.low: 25
+battery.charger.status: resting
+battery.current: 0.264
+battery.packs: 1
+battery.packs.bad: 0
+battery.temperature: 251	#BAD: Probably a 10x factor error
+battery.type: LiPO
+battery.voltage: 3.700
+battery.voltage.nominal: 4.180
+device.mfr: PiJuice
+device.type: HAT
+driver.name: pijuice
+driver.parameter.pollinterval: 2
+driver.parameter.port: /dev/i2c-1
+driver.parameter.synchronous: no
+driver.version: 2.7.4-4385-g2bd17f540
+driver.version.internal: 0.9
+input.current: 0.064
+input.voltage: 4.988
+ups.date: 2022-01-21
+ups.firmware: 1.4
+ups.mfr: PiJuice
+ups.status: OL
+ups.time: 21:48:40.38
+ups.type: HAT

--- a/PiSupply/PiSupply__PiJuice_HAT__pijuice__2.8.0__04.dev
+++ b/PiSupply/PiSupply__PiJuice_HAT__pijuice__2.8.0__04.dev
@@ -1,0 +1,38 @@
+# DEVICE:URL:REPORT: https://github.com/PiSupply/PiJuice/issues/124#issuecomment-2019031200
+# DEVICE:URL:VENDOR: https://uk.pi-supply.com/products/pijuice-standard
+
+# DEVICE:COMMENT-BLOCK:UPSCONF:
+# # Using NUT v2.8.0 packaged in Debian 12 (Bookworm)
+# [pijuice-ups]
+#     driver = pijuice
+#     port = /dev/i2c-1
+#     desc = "PiJuice HAT"
+# DEVICE:EOC
+
+battery.capacity: 1.000
+battery.charge: 96.8
+battery.charge.low: 25
+battery.charger.status: resting
+battery.current: 0.000
+battery.packs: 1
+battery.packs.bad: 0
+battery.temperature: -232
+battery.type: LiPO
+battery.voltage: 4.128
+battery.voltage.nominal: 4.180
+device.mfr: PiJuice
+device.type: HAT
+driver.name: pijuice
+driver.parameter.pollinterval: 2
+driver.parameter.port: /dev/i2c-1
+driver.parameter.synchronous: auto
+driver.version: 2.8.0
+driver.version.internal: 0.10
+input.current: 2.987
+input.voltage: 5.227
+ups.date: 2024-03-25
+ups.firmware: 1.6
+ups.mfr: PiJuice
+ups.status: HB OL
+ups.time: 22:28:16.44
+ups.type: HAT

--- a/PiSupply/PiSupply__PiJuice_HAT__pijuice__2.8.3__01.dev
+++ b/PiSupply/PiSupply__PiJuice_HAT__pijuice__2.8.3__01.dev
@@ -1,0 +1,32 @@
+# DEVICE:URL:VENDOR: https://uk.pi-supply.com/products/pijuice-standard
+
+battery.capacity: 12.000
+battery.charge: 22.8
+battery.charge.low: 25
+battery.charger.status: charging
+battery.current: -0.915	#BAD: Not really bad, battery is charging over GPIO with power plugged into Pi itself, not the HAT
+battery.packs: 1
+battery.packs.bad: 0
+battery.temperature: -213	#BAD: Probably a 10x factor error, and for some reason inverted (also in vendor tools, says -2*C there though - a 100x factor?)
+battery.type: LiPO
+battery.voltage: 3.757
+battery.voltage.nominal: 4.180
+device.mfr: PiJuice
+device.type: HAT
+driver.debug: 0
+driver.flag.allow_killpower: 0
+driver.name: pijuice
+driver.parameter.pollinterval: 2
+driver.parameter.port: /dev/i2c-1
+driver.parameter.synchronous: auto
+driver.state: dumping
+driver.version: 2.8.3.446-446+g10ac93004
+driver.version.internal: 0.14
+input.current: -0.314	#BAD: Not really bad, battery is charging over GPIO with power plugged into Pi itself, not the HAT
+input.voltage: 5.022
+ups.date: 2000-01-01	#BAD: HAT RTC clock not set yet
+ups.firmware: 1.6
+ups.mfr: PiJuice
+ups.status: LB OL CHRG
+ups.time: 02:31:41.24
+ups.type: HAT

--- a/PiSupply/PiSupply__PiJuice_HAT__pijuice__2.8.3__02.dev
+++ b/PiSupply/PiSupply__PiJuice_HAT__pijuice__2.8.3__02.dev
@@ -1,0 +1,32 @@
+# DEVICE:URL:VENDOR: https://uk.pi-supply.com/products/pijuice-standard
+
+battery.capacity: 12.000
+battery.charge: 53.1
+battery.charge.low: 25
+battery.charger.status: charging
+battery.current: -0.377	#BAD: Not really bad, battery is charging over GPIO with power plugged into Pi itself, not the HAT
+battery.packs: 1
+battery.packs.bad: 0
+battery.temperature: -215
+battery.type: LiPO
+battery.voltage: 3.878
+battery.voltage.nominal: 4.180
+device.mfr: PiJuice
+device.type: HAT
+driver.debug: 0
+driver.flag.allow_killpower: 0
+driver.name: pijuice
+driver.parameter.pollinterval: 2
+driver.parameter.port: /dev/i2c-1
+driver.parameter.synchronous: auto
+driver.state: quiet
+driver.version: 2.8.3.451-451+g4e43368c4
+driver.version.internal: 0.14
+input.current: 0.071	#BAD: Not really bad, battery is charging over GPIO with power plugged into Pi itself, not the HAT; the reported current fluctuates (and even the sign changes) as the battery gets more full
+input.voltage: 5.025
+ups.date: 2025-06-11
+ups.firmware: 1.6
+ups.mfr: PiJuice
+ups.status: OL CHRG
+ups.time: 06:37:21.27
+ups.type: HAT

--- a/PiSupply/PiSupply__PiJuice_Zero_pHAT__pijuice__2.8.0__01.dev
+++ b/PiSupply/PiSupply__PiJuice_Zero_pHAT__pijuice__2.8.0__01.dev
@@ -1,0 +1,163 @@
+# DEVICE:URL:REPORT: https://github.com/PiSupply/PiJuice/issues/124#issuecomment-1018603688
+# DEVICE:URL:VENDOR: https://uk.pi-supply.com/products/pijuice-standard
+
+# DEVICE:COMMENT-BLOCK:UPSCONF:
+# [hat]
+#     driver = pijuice
+#     port = /dev/i2c-1
+#     desc = "PiJuice HAT"
+# DEVICE:EOC
+
+# DEVICE:COMMENT-BLOCK: (In-)stability
+# Strangely, after a couple of days on miniUSB power (although plugged from a
+# laptop -- maybe power did not suffice, at least Pi rebooted rather often),
+# the hardwired big battery never went over "battery.charge: 47.6" reading.
+# Popped back the 1820mAh into the PiJuice, and it is quickly growing from ~3
+# to ~60 by now, with flashing blue-green light near SW1 button, with the same
+# USB connection. It first seemed the batteries are not charging if the USB-C
+# Raspberry Pi4 power input is used, but with another cable and another source
+# they do.
+# DEVICE:EOC
+
+# DEVICE:COMMENT-BLOCK: DRIVER START LOG
+#    0.000000     [D5] send_to_all: SETINFO driver.parameter.port "/dev/i2c-1"
+#    0.000222     [D1] debug level is '6'
+#    0.001321     [D5] send_to_all: SETINFO device.type "ups"
+#    0.001473     [D3] get_firmware_version
+#    0.002926     Unknown Firmware release: 1.4
+#    0.002987     [D1] UPS Firmware Version: 1.4
+#    0.003045     [D5] send_to_all: SETINFO ups.firmware "1.4"
+#    0.003107     [D5] send_to_all: SETINFO driver.version "2.7.4-4385-g2bd17f540"
+#    0.003165     [D5] send_to_all: SETINFO driver.version.internal "0.9"
+#    0.003223     [D5] send_to_all: SETINFO driver.name "pijuice"
+#    0.003281     [D5] send_to_all: SETINFO ups.mfr "PiJuice"
+#    0.003340     [D5] send_to_all: SETINFO ups.type "HAT"
+#    0.003397     [D5] send_to_all: SETINFO device.mfr "PiJuice"
+#    0.003454     [D5] send_to_all: SETINFO device.type "HAT"
+#    0.003511     [D1] Low Battery Threshold: 25%
+#    0.003569     [D5] send_to_all: SETINFO battery.charge.low "25"
+#    0.003624     [D1] Nominal Battery Voltage: 4.180V
+#    0.003681     [D5] send_to_all: SETINFO battery.voltage.nominal "4.180"
+#    0.003732     [D3] get_i2c_address
+#    0.004962     [D1] I2C Address: 0x14
+#    0.005060     [D1] Found device '0x14' on port '/dev/i2c-1'
+#    0.005111     [D3] get_battery_profile
+#    0.009269     [D1] Battery Capacity: 1.000Ah
+#    0.009348     [D5] send_to_all: SETINFO battery.capacity "1.000"
+#    0.009400     [D3] get_battery_profile_ext
+#    0.014219     [D1] Battery Chemistry: LiPO
+#    0.014293     [D5] send_to_all: SETINFO battery.type "LiPO"
+#    0.014349     [D3] get_status
+#    0.015548     [D1] Battery Status: Normal
+#    0.015613     [D5] send_to_all: SETINFO battery.packs "1"
+#    0.015673     [D5] send_to_all: SETINFO battery.packs.bad "0"
+#    0.015724     [D1] Power Input: Not Present
+#    0.015774     [D1] Power Input 5v: Not Present
+#    0.015823     [D3] get_charge_level_hi_res
+#    0.017242     [D1] Battery Charge Level: 51.4%
+#    0.017318     [D5] send_to_all: SETINFO battery.charge "51.4"
+#    0.017372     [D1] On Battery power [0:0:1]
+#    0.017424     [D3] get_battery_temperature
+#    0.018836     [D1] Battery Temperature: 248°C
+#    0.018900     [D5] send_to_all: SETINFO battery.temperature "248"
+#    0.018952     [D3] get_battery_voltage
+#    0.020365     [D1] Battery Voltage: 3.709V
+#    0.020429     [D5] send_to_all: SETINFO battery.voltage "3.709"
+#    0.020479     [D3] get_battery_current
+#    0.021896     [D1] Battery Current: 0.000A
+#    0.021968     [D5] send_to_all: SETINFO battery.current "0.000"
+#    0.022018     [D3] get_io_voltage
+#    0.023444     [D1] Input Voltage: 5.094V
+#    0.023508     [D5] send_to_all: SETINFO input.voltage "5.094"
+#    0.023558     [D3] get_io_current
+#    0.024990     [D1] Input Current: 0.012A
+#    0.025063     [D5] send_to_all: SETINFO input.current "0.012"
+#    0.025113     [D3] get_time
+#    0.028144     [D1] UPS Time: 00:03:11.46
+#    0.028210     [D5] send_to_all: SETINFO ups.time "00:03:11.46"
+#    0.028263     [D1] UPS Date: 2000-01-01
+#    0.028318     [D5] send_to_all: SETINFO ups.date "2000-01-01"
+#    0.028369     [D3] get_power_off
+#    0.029556     [D1] Power Off: 127 Seconds
+#    0.029628     [D5] send_to_all: SETINFO ups.status "OB DISCHRG"
+#    0.029682     [D5] send_to_all: DATAOK
+#    0.029739     [D5] send_to_all: SETINFO driver.parameter.pollinterval "2"
+#    0.029797     [D5] send_to_all: SETINFO driver.parameter.synchronous "no"
+#    0.029854     [D3] get_status
+#    0.031051     [D1] Battery Status: Normal
+#    0.031111     [D1] Power Input: Not Present
+#    0.031161     [D1] Power Input 5v: Not Present
+#    0.031210     [D3] get_charge_level_hi_res
+#    0.032625     [D1] Battery Charge Level: 51.4%
+#    0.032686     [D1] On Battery power [0:0:1]
+#    0.032775     [D3] get_battery_temperature
+#    0.034202     [D1] Battery Temperature: 248°C
+#    0.034261     [D3] get_battery_voltage
+#    0.035675     [D1] Battery Voltage: 3.709V
+#    0.035733     [D3] get_battery_current
+#    0.037147     [D1] Battery Current: 0.000A
+#    0.037214     [D3] get_io_voltage
+#    0.038638     [D1] Input Voltage: 5.094V
+#    0.038697     [D3] get_io_current
+#    0.040122     [D1] Input Current: 0.012A
+#    0.040181     [D3] get_time
+#    0.043213     [D1] UPS Time: 00:03:11.45
+#    0.043287     [D5] send_to_all: SETINFO ups.time "00:03:11.45"
+#    0.043338     [D1] UPS Date: 2000-01-01
+#    0.043391     [D3] get_power_off
+#    0.044572     [D1] Power Off: 127 Seconds
+#    0.044633     [D3] get_status
+#    0.045834     [D1] Battery Status: Normal
+#    0.045903     [D1] Power Input: Not Present
+#    0.046002     [D1] Power Input 5v: Not Present
+#    0.046053     [D3] get_charge_level_hi_res
+#    0.047469     [D1] Battery Charge Level: 51.4%
+#    0.047530     [D1] On Battery power [0:0:1]
+#    0.047581     [D3] get_battery_temperature
+#    0.048994     [D1] Battery Temperature: 248°C
+#    0.049062     [D3] get_battery_voltage
+#    0.050476     [D1] Battery Voltage: 3.709V
+#    0.050534     [D3] get_battery_current
+#    0.051948     [D1] Battery Current: 0.000A
+#    0.052007     [D3] get_io_voltage
+#    0.053434     [D1] Input Voltage: 5.094V
+#    0.053501     [D3] get_io_current
+#    0.054924     [D1] Input Current: 0.012A
+#    0.054983     [D3] get_time
+#    0.058016     [D1] UPS Time: 00:03:11.43
+#    0.058090     [D5] send_to_all: SETINFO ups.time "00:03:11.43"
+#    0.058142     [D1] UPS Date: 2000-01-01
+#    0.058194     [D3] get_power_off
+#    0.059374     [D1] Power Off: 127 Seconds
+#    0.059434     [D3] Entering dstate_dump
+# Network UPS Tools - PiJuice UPS driver 0.9 (2.7.4-4385-g2bd17f540)
+# Warning: This is an experimental driver.
+# Some features may not function correctly.
+# DEVICE:EOC
+
+battery.capacity: 1.000	#BAD: Actual battery was 1820 mAh; possibly wrong DIP switch combo was in place to configure the HAT
+battery.charge: 51.4
+battery.charge.low: 25
+battery.current: 0.000
+battery.packs: 1
+battery.packs.bad: 0
+battery.temperature: 248
+battery.type: LiPO
+battery.voltage: 3.709
+battery.voltage.nominal: 4.180
+device.mfr: PiJuice
+device.type: HAT
+driver.name: pijuice
+driver.parameter.pollinterval: 2
+driver.parameter.port: /dev/i2c-1
+driver.parameter.synchronous: no
+driver.version: 2.7.4-4385-g2bd17f540
+driver.version.internal: 0.9
+input.current: 0.012
+input.voltage: 5.094
+ups.date: 2000-01-01
+ups.firmware: 1.4
+ups.mfr: PiJuice
+ups.status: OB DISCHRG
+ups.time: 00:03:11.43
+ups.type: HAT


### PR DESCRIPTION
v2.8.0 (some technically tagged as post-2.7.4, from PR that introduced the driver)
* https://github.com/networkupstools/nut/pull/730
* https://github.com/PiSupply/PiJuice/issues/124

v2.8.3 with same HAT and 12000 mAh battery reported years ago, that were dormant for a while, with a recent NUT build (and a Raspberry Pi5). Tested during work on https://github.com/networkupstools/nut/pull/2985 ; re-discovered old issues like bogus temperature reports.